### PR TITLE
Feat: filter AND/OR combo behaviour setting

### DIFF
--- a/content/data/settings.json
+++ b/content/data/settings.json
@@ -9,9 +9,9 @@
     "firstTag": "",
     "lastTag": "none",
     "externalLinksTargetBlank": true,
-    "tagMatchType": "or",
+    "tagMatchType": "and",
     "targetCategoryMatch": [
-      { "categorySlug": "project-category", "tagMatchType": "and" },
+      { "categorySlug": "project-category", "tagMatchType": "or" },
       { "categorySlug": "storage-type", "tagMatchType": "or" },
       { "categorySlug": "software-type", "tagMatchType": "or" },
       { "categorySlug": "tooling", "tagMatchType": "or" },


### PR DESCRIPTION
Option added to target a specific tag category using its slug name and specify the type of filtering it should apply to all projects _before_ the main filtering option (`behavior.tagMatchType`).

This new option exists at `behavior.targetCategoryMatch` and is an object with two properties: first, `categorySlug`, to specify the target category and second another `tagMatchType` to specify what kind of filtering this option will employ. Options are "and" / "or".