### PR TITLE
chore: updated packages

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -62,13 +62,13 @@ export default {
   // ---------------------------------------------------------------------------
   modules: [
     // Doc: https://github.com/ipfs-shipyard/nuxt-module-ecosystem-directory
-    'nuxt-module-ecosystem-directory',
+    '@agency-undone/nuxt-module-ecosystem-directory',
     // Doc: https://axios.nuxtjs.org/usage
     '@nuxtjs/axios',
     // Doc: https://github.com/nuxt-community/style-resources-module/
     '@nuxtjs/style-resources',
     // Doc: https://github.com/agency-undone/nuxt-module-ipfs
-    'nuxt-module-ipfs'
+    '@agency-undone/nuxt-module-ipfs'
   ],
   // ///////////////////////////////////////////////////////////// [Module] Zero
   // ---------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,50 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@agency-undone/au-nuxt-module-zero": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@agency-undone/au-nuxt-module-zero/-/au-nuxt-module-zero-1.0.13.tgz",
+      "integrity": "sha512-p4JVx+blgcMS3yXJgAfIcXKd8U+CVMe94MHxKPRyR3MO0Fs7uWX+EkBEjeuxm+iqWBGHWEFMsezVt32UW2U0wQ==",
+      "requires": {
+        "@nuxtjs/sitemap": "^2.4.0",
+        "cookie": "^0.4.1",
+        "lodash": "^4.17.21",
+        "nuxt-hammer": "^2.1.3",
+        "vue-ls": "^3.2.2",
+        "vue-uuid": "^2.0.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "@agency-undone/nuxt-module-ecosystem-directory": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.16.tgz",
+      "integrity": "sha512-KzfZ5a+owdF01Bj+VyGNNA5wEzTrGjN9k5B7tiweRxCkB+s30K8WtoechNoPFwIh+zFc0zfZZPewe7xZEK4MRA==",
+      "requires": {
+        "@agency-undone/au-nuxt-module-zero": "^1.0.13",
+        "countly-sdk-web": "^20.11.2",
+        "filesize": "^8.0.0",
+        "fs-extra": "^10.0.0"
+      }
+    },
+    "@agency-undone/nuxt-module-ipfs": {
+      "version": "1.0.2-alpha.3",
+      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ipfs/-/nuxt-module-ipfs-1.0.2-alpha.3.tgz",
+      "integrity": "sha512-nTGVx6V4yh8KymkmnVqFXXvukRnxbR6U8Y3grSl3+Drnp3xP7OHnrUugYQCXlgmpPaLscFjIwGJaqjjmUjP+dg==",
+      "requires": {
+        "klaw": "^3.0.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -3185,6 +3229,47 @@
         "http-proxy-middleware": "^1.0.6"
       }
     },
+    "@nuxtjs/sitemap": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/sitemap/-/sitemap-2.4.0.tgz",
+      "integrity": "sha512-TVgIYOtPp7KAfaUo76WRpGbO20j4D/xi/A7shFIGjARHs+FvfAWXNCtBT87dTwe/RoYzAsEKtijFFUTaSu5bUA==",
+      "requires": {
+        "async-cache": "^1.1.0",
+        "consola": "^2.13.0",
+        "etag": "^1.8.1",
+        "fresh": "^0.5.2",
+        "fs-extra": "^8.1.0",
+        "is-https": "^2.0.2",
+        "lodash.unionby": "^4.8.0",
+        "minimatch": "^3.0.4",
+        "sitemap": "^4.1.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
+      }
+    },
     "@nuxtjs/style-resources": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@nuxtjs/style-resources/-/style-resources-1.2.1.tgz",
@@ -3289,6 +3374,14 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
+    "@types/sax": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.3.tgz",
+      "integrity": "sha512-+QSw6Tqvs/KQpZX8DvIl3hZSjNFLW/OqE5nlyHXtTwODaJvioN2rOWpBNEWZp2HZUFhOh+VohmJku/WxEXU2XA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -3315,9 +3408,9 @@
       }
     },
     "@types/uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
+      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA=="
     },
     "@types/webpack": {
       "version": "4.41.27",
@@ -4196,6 +4289,30 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
       "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
     },
+    "async-cache": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.1.0.tgz",
+      "integrity": "sha1-SppaidBl7F2OUlS9nulrp2xTK1o=",
+      "requires": {
+        "lru-cache": "^4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -4221,30 +4338,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-    },
-    "au-nuxt-module-zero": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/au-nuxt-module-zero/-/au-nuxt-module-zero-1.0.4.tgz",
-      "integrity": "sha512-GAOr4biX9zcljT63qTZmEhOeRfM71Lia5gBRi+Ze5T5BAuslXEw7EW+8X+o0CUG9x8k5u3+4Ncg0KMwQEBfUVg==",
-      "requires": {
-        "cookie": "^0.4.1",
-        "lodash": "^4.17.21",
-        "nuxt-hammer": "^2.1.3",
-        "vue-ls": "^3.2.2",
-        "vue-uuid": "^2.0.2"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
-      }
     },
     "autoprefixer": {
       "version": "9.8.6",
@@ -7308,9 +7401,9 @@
       "optional": true
     },
     "filesize": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.5.tgz",
-      "integrity": "sha512-nW6kfJQIL+FY63PWbyxyRKDSFqm3aomjcMfydPzlOn7HiLnY9jPnbRuawroqGGQHEceDxUQEaF0RYy94irvsEw=="
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.6.tgz",
+      "integrity": "sha512-sHvRqTiwdmcuzqet7iVwsbwF6UrV3wIgDf2SHNdY1Hgl8PC45HZg/0xtdw6U2izIV4lccnrY9ftl6wZFNdjYMg=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -8630,6 +8723,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-https": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-https/-/is-https-2.0.2.tgz",
+      "integrity": "sha512-UfUCKVQH/6PQRCh5Qk9vNu4feLZiFmV/gr8DjbtJD0IrCRIDTA6E+d/AVFGPulI5tqK5W45fYbn1Nir1O99rFw=="
+    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -9026,6 +9124,11 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
+    },
+    "lodash.unionby": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lodash.unionby/-/lodash.unionby-4.8.0.tgz",
+      "integrity": "sha1-iD8Jj/ePVkpye3UI4JzdU5c0u4M="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -9953,25 +10056,6 @@
       "requires": {
         "@squadette/hammerjs": "^2.1.0-pre3",
         "babel-runtime": "^6.26.0"
-      }
-    },
-    "nuxt-module-ecosystem-directory": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.14.tgz",
-      "integrity": "sha512-lfY9BGBR0mEzXAaLMn1/2IFpBu3UW45E862P2WVbqHtoVZBTDLNCFfyOS+AoMa7NMsA8sebkUVZ+ij+tYzsJTQ==",
-      "requires": {
-        "au-nuxt-module-zero": "^1.0.2",
-        "countly-sdk-web": "^20.11.2",
-        "filesize": "^8.0.0",
-        "fs-extra": "^10.0.0"
-      }
-    },
-    "nuxt-module-ipfs": {
-      "version": "1.0.2-alpha.2",
-      "resolved": "https://registry.npmjs.org/nuxt-module-ipfs/-/nuxt-module-ipfs-1.0.2-alpha.2.tgz",
-      "integrity": "sha512-JYiqLBk6QB7YZR5m0AKbd0lC+7T4LvIyqqOizNZZ+V8NeKAQDCZQCpZfQs0InEZM+vbTbhV4/r7aa4cNzeWGNA==",
-      "requires": {
-        "klaw": "^3.0.0"
       }
     },
     "oauth-sign": {
@@ -12583,6 +12667,30 @@
         "totalist": "^1.0.0"
       }
     },
+    "sitemap": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-4.1.1.tgz",
+      "integrity": "sha512-+8yd66IxyIFEMFkFpVoPuoPwBvdiL7Ap/HS5YD7igqO4phkyTPFIprCAE9NMHehAY5ZGN3MkAze4lDrOAX3sVQ==",
+      "requires": {
+        "@types/node": "^12.0.2",
+        "@types/sax": "^1.2.0",
+        "arg": "^4.1.1",
+        "sax": "^1.2.4",
+        "xmlbuilder": "^13.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.37",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
+          "integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA=="
+        },
+        "arg": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+        }
+      }
+    },
     "slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -14656,6 +14764,11 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
       "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
+    },
+    "xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "node": ">=14.17.6"
   },
   "dependencies": {
+    "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.16",
+    "@agency-undone/nuxt-module-ipfs": "^1.0.2-alpha.3",
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/eslint-config": "^6.0.1",
     "@nuxtjs/eslint-module": "^3.0.2",
@@ -31,8 +33,6 @@
     "mobile-device-detect": "^0.4.3",
     "node-sass": "^6.0.1",
     "nuxt": "^2.15.4",
-    "nuxt-module-ecosystem-directory": "^1.0.14",
-    "nuxt-module-ipfs": "^1.0.2-alpha.2",
     "raw-loader": "^4.0.2",
     "sass": "^1.38.2",
     "sass-loader": "^10.1.1",


### PR DESCRIPTION
Swapped out `nuxt-module-ecosystem-directory` and `nuxt-module-ipfs` for their namespaced @agency-undone counterparts