### PR TITLE
feat: Set link truncation via config

### DIFF
--- a/content/data/settings.json
+++ b/content/data/settings.json
@@ -36,6 +36,7 @@
     "hideSort": false,
     "hideNumResults": false,
     "setSort": "a_z",
+    "truncateCharacters": [10, 12],
     "setPageSize": 20,
     "disableSingulars": 2,
     "truncateLinks": true,


### PR DESCRIPTION
Adds a setting called `truncateCharacters`, which can set the number of characters before and after the ellipsis when truncating links on the project singular page. This key takes an array of one or two values (if one value is set, the characters before and after are equivalent).

```json
"truncateCharacters": [3, 6]
```

This would result in a truncation of `http://un.org` to 

`htt` `...` `un.org`