### PR TITLE
fix Segment slider xl

### DIFF
--- a/assets/scss/components.scss
+++ b/assets/scss/components.scss
@@ -221,8 +221,14 @@
 // -----------------------------------------------------------------------------
 
 #segment-slider-chart {
-  @include medium {
+  .main-container {
+    flex-wrap: nowrap;
+  }
+  @include xlarge {
     background-color: transparent;
+    .main-container {
+      flex-wrap: wrap-reverse;
+    }
     .segments-container {
       background-color: inherit;
       .chart-title {

--- a/assets/scss/utilities.scss
+++ b/assets/scss/utilities.scss
@@ -62,6 +62,7 @@
 @mixin large { @media screen and (max-width: $breakpoint_Large) { @content; } }
 @mixin xlarge { @media screen and (max-width: $breakpoint_Xlarge) { @content; } }
 @mixin ultraLarge { @media screen and (max-width: $breakpoint_UltraLarge) { @content; } }
+@mixin ultraPlus { @media screen and (min-width: $breakpoint_UltraLarge) { @content; } }
 
 @mixin containerMaxMQ { @media screen and (max-width: $containerWidth) { @content; } }
 @mixin containerMinMQ { @media screen and (max-width: $containerWidthPlusOnePixel) { @content; } }


### PR DESCRIPTION
Fixes an issue where the segment chart would take up full width on extra large screens, pushing the chart and the slider to separate full width rows