### PR TITLE
fix Publicize site

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,9 +1,0 @@
-<template>
-  <div></div>
-</template>
-
-<script>
-export default {
-  name: 'PlaceholderHomePage'
-}
-</script>


### PR DESCRIPTION
Enables the ability to see the public site by removing an empty `index.vue` file (originally added in https://github.com/filecoin-project/ecodash/pull/62/commits/722481f9558b328d3222792517a7814c3d472141).