### PR TITLE
fix: Unset max-width on card icons

### DIFF
--- a/assets/scss/components.scss
+++ b/assets/scss/components.scss
@@ -688,6 +688,7 @@
   .thumbnail {
     border-radius: 0 !important;
     img {
+      max-width: unset !important;
       height: 75px;
     }
   }


### PR DESCRIPTION
Unset max-width on card icons