### PR TITLE
feat: Optional project number display in index filters section heading

### DIFF
--- a/content/data/settings.json
+++ b/content/data/settings.json
@@ -42,7 +42,8 @@
     "truncateLinks": true,
     "mediaAltAtts": true,
     "linksAltAtts": true,
-    "singularTagLinks": true
+    "singularTagLinks": true,
+    "indexHeadingEntityCount": true
   },
   "embeddable_view": {
     "host": "https://ecosystem.filecoin.io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@agency-undone/au-nuxt-module-zero": "^1.0.18",
-        "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.22",
+        "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.24",
         "@agency-undone/nuxt-module-ipfs": "^1.0.2-alpha.4",
         "@nuxtjs/eslint-config": "^7.0.0",
         "@nuxtjs/eslint-module": "^3.0.2",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@agency-undone/nuxt-module-ecosystem-directory": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.22.tgz",
-      "integrity": "sha512-6geZclq3OVcXobRuWqkfPrMibJUpuThIncyKXfL1M122QGKiZmpAFMjeUcPmv3ZjMLVMbUWLyV1zlN1MZ0ELRg==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.24.tgz",
+      "integrity": "sha512-qGssxmwDuT1DdDhh7A/GHxjMYvG/pWtKXJ2wZw07mNFfIYaG0Hy5JCxGtC+6MIqzSPXDzC756TA92GiI7Si9fg==",
       "dependencies": {
         "@agency-undone/au-nuxt-module-zero": "^1.0.16",
         "countly-sdk-web": "^20.11.3",
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@agency-undone/nuxt-module-ecosystem-directory/node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -6635,9 +6635,9 @@
       "optional": true
     },
     "node_modules/filesize": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.6.tgz",
-      "integrity": "sha512-sHvRqTiwdmcuzqet7iVwsbwF6UrV3wIgDf2SHNdY1Hgl8PC45HZg/0xtdw6U2izIV4lccnrY9ftl6wZFNdjYMg==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
+      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -15483,9 +15483,9 @@
       }
     },
     "@agency-undone/nuxt-module-ecosystem-directory": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.22.tgz",
-      "integrity": "sha512-6geZclq3OVcXobRuWqkfPrMibJUpuThIncyKXfL1M122QGKiZmpAFMjeUcPmv3ZjMLVMbUWLyV1zlN1MZ0ELRg==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.24.tgz",
+      "integrity": "sha512-qGssxmwDuT1DdDhh7A/GHxjMYvG/pWtKXJ2wZw07mNFfIYaG0Hy5JCxGtC+6MIqzSPXDzC756TA92GiI7Si9fg==",
       "requires": {
         "@agency-undone/au-nuxt-module-zero": "^1.0.16",
         "countly-sdk-web": "^20.11.3",
@@ -15494,9 +15494,9 @@
       },
       "dependencies": {
         "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -20517,9 +20517,9 @@
       "optional": true
     },
     "filesize": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.6.tgz",
-      "integrity": "sha512-sHvRqTiwdmcuzqet7iVwsbwF6UrV3wIgDf2SHNdY1Hgl8PC45HZg/0xtdw6U2izIV4lccnrY9ftl6wZFNdjYMg=="
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
+      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@agency-undone/au-nuxt-module-zero": "^1.0.18",
-    "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.22",
+    "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.24",
     "@agency-undone/nuxt-module-ipfs": "^1.0.2-alpha.4",
     "@nuxtjs/eslint-config": "^7.0.0",
     "@nuxtjs/eslint-module": "^3.0.2",


### PR DESCRIPTION
Added option to the site settings object: `"indexHeadingEntityCount": true` will enable the index page filters section heading to display the total number of projects in the ecosystem directory in the format; `string + n + projects`, ex: "All 97 Projects".
This PR only adds to the `settings.json` and `package.json` files as the feature itself has been built in the nuxt-module-ecosystem-directory npm package.