### PR TITLE
feat: Default filters option

### DIFF
--- a/content/data/settings.json
+++ b/content/data/settings.json
@@ -19,7 +19,16 @@
       { "categorySlug": "project-status", "tagMatchType": "or" }
     ],
     "excludeFilterAllTag": true,
-    "includeGranularFilterClearButton": true
+    "includeGranularFilterClearButton": true,
+    "defaultSelectedFilters": [
+      "api",
+      "library-sdk",
+      "hosted-service",
+      "network",
+      "backend-app",
+      "mobile-app",
+      "web-app"
+    ]
   },
   "visibility": {
     "excludeSingulars": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@agency-undone/au-nuxt-module-zero": "^1.0.18",
-        "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.24",
+        "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.25",
         "@agency-undone/nuxt-module-ipfs": "^1.0.2-alpha.4",
         "@nuxtjs/eslint-config": "^7.0.0",
         "@nuxtjs/eslint-module": "^3.0.2",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@agency-undone/nuxt-module-ecosystem-directory": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.24.tgz",
-      "integrity": "sha512-qGssxmwDuT1DdDhh7A/GHxjMYvG/pWtKXJ2wZw07mNFfIYaG0Hy5JCxGtC+6MIqzSPXDzC756TA92GiI7Si9fg==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.25.tgz",
+      "integrity": "sha512-+k2jpgeA+P8nyYpCS8CIwXC/GGuXE+xVEMK1GUERGhtB0olD4sYIBJrb4FThjPKXRMhImQeoaR+fOJUjMuuKDg==",
       "dependencies": {
         "@agency-undone/au-nuxt-module-zero": "^1.0.16",
         "countly-sdk-web": "^20.11.3",
@@ -15483,9 +15483,9 @@
       }
     },
     "@agency-undone/nuxt-module-ecosystem-directory": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.24.tgz",
-      "integrity": "sha512-qGssxmwDuT1DdDhh7A/GHxjMYvG/pWtKXJ2wZw07mNFfIYaG0Hy5JCxGtC+6MIqzSPXDzC756TA92GiI7Si9fg==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.25.tgz",
+      "integrity": "sha512-+k2jpgeA+P8nyYpCS8CIwXC/GGuXE+xVEMK1GUERGhtB0olD4sYIBJrb4FThjPKXRMhImQeoaR+fOJUjMuuKDg==",
       "requires": {
         "@agency-undone/au-nuxt-module-zero": "^1.0.16",
         "countly-sdk-web": "^20.11.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@agency-undone/au-nuxt-module-zero": "^1.0.18",
-    "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.24",
+    "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.25",
     "@agency-undone/nuxt-module-ipfs": "^1.0.2-alpha.4",
     "@nuxtjs/eslint-config": "^7.0.0",
     "@nuxtjs/eslint-module": "^3.0.2",


### PR DESCRIPTION
Default filters can be set to load automatically on app load. These can be set by adding tags (in slug form) to the `"defaultSelectedFilters"` array under the `behavior` key in the site settings json. Note navigating to the site with the tags url param pre-populated will override the default filters selection.