### PR TITLE
feat: plausible analytics

### DIFF
--- a/middleware/plausible.js
+++ b/middleware/plausible.js
@@ -1,13 +1,18 @@
 let isInitialPageLoad = true
 
 export default function (context) {
+  // ENV must be production
+  if (process.env.NODE_ENV !== 'production') {
+    return
+  }
+
   // Ignore initial page because it's fired in the head
   if (isInitialPageLoad) {
     isInitialPageLoad = false
     return
   }
 
-  // Exclude server side
+  // Exclude server side middleware
   if (process.client) {
     // Track virtual navigation changes
     window.plausible = window.plausible || function() {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -35,15 +35,17 @@ export default {
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon/favicon.ico' }
     ],
-    script: [
-      {
-        hid: 'plausible',
-        src: 'https://plausible.io/js/plausible.js',
-        'data-domain': 'ecosystem.filecoin.io',
-        async: true,
-        defer: true
-      }
-    ]
+    script: process.env.NODE_ENV === 'production'
+      ? [
+          {
+            hid: 'plausible',
+            src: 'https://plausible.io/js/plausible.js',
+            'data-domain': 'ecosystem.filecoin.io',
+            async: true,
+            defer: true
+          }
+        ]
+      : []
   },
   // ////////////////////////////////////////// Customize the progress-bar color
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Initial eventless configuration for Plausible Analytics. Needs testing, but this should track virtual route changes as well as the initial page load.

- [x] Only runs client-side and therefore works for static sites
- [x] Is fired in the head 
- [x] Is also fired on virtual route changes
- [x] Only fires in prod (`process.env.NODE_ENV` must be `production`)

Uses Nuxt's native `middleware` directory.
@timelytree alternatively it could be a module that I import. What do you think?