### PR TITLE
chore: add fleek config

### DIFF
--- a/.fleek.json
+++ b/.fleek.json
@@ -1,0 +1,10 @@
+{
+    "build": {
+      "image": "node:16.14",
+      "command": "npm ci && npm run generate",
+      "publicDir": "dist",
+      "environment": {
+        "SERVER_ENV": "production"
+      }
+    }
+}


### PR DESCRIPTION
Simply adds a fleek configuration file, just so that we don't have to reconfigure as much when moving domains and such. The `NODE_ENV` still needs to be added manually though, because it differs in production vs. staging.