### PR TITLE
chore: redirect to fil.org/ecosystem

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+# 301 catch all redirect
+/*  https://fil.org/ecosystem


### PR DESCRIPTION
Site is unmaintained, redirecting to https://fil.org/ecosystem.